### PR TITLE
Unhardcode RDP launcher; use config-defined client with presets (3.0.7)

### DIFF
--- a/go-client/config.json
+++ b/go-client/config.json
@@ -100,6 +100,57 @@
         "is_set": true
       },
       {
+        "name": "royalts",
+        "display_name": "Royal TS",
+        "protocol": ["rdp"],
+        "comment": {
+          "zh": "Royal TS 是一款强大的远程连接管理工具。",
+          "en": "Royal TS is a powerful remote connection manager."
+        },
+        "download_url": "https://www.royalapps.com/ts/windows",
+        "type": "remotedesktop",
+        "path": "",
+        "arg_format": "{file}",
+        "match_first": ["rdp"],
+        "is_internal": false,
+        "is_default": false,
+        "is_set": false
+      },
+      {
+        "name": "windows_rdm",
+        "display_name": "Remote Desktop Manager",
+        "protocol": ["rdp"],
+        "comment": {
+          "zh": "Remote Desktop Manager (Devolutions) 集中管理所有远程连接。",
+          "en": "Remote Desktop Manager (Devolutions) centralizes all remote connections."
+        },
+        "download_url": "https://remotedesktopmanager.com/",
+        "type": "remotedesktop",
+        "path": "",
+        "arg_format": "{file}",
+        "match_first": ["rdp"],
+        "is_internal": false,
+        "is_default": false,
+        "is_set": false
+      },
+      {
+        "name": "moba_rdp",
+        "display_name": "MobaXterm (RDP)",
+        "protocol": ["rdp"],
+        "comment": {
+          "zh": "MobaXterm 支持 RDP/VNC/SSH 等多种协议。",
+          "en": "MobaXterm supports RDP/VNC/SSH and more."
+        },
+        "download_url": "https://mobaxterm.mobatek.net/download.html",
+        "type": "remotedesktop",
+        "path": "",
+        "arg_format": "{file}",
+        "match_first": ["rdp"],
+        "is_internal": false,
+        "is_default": false,
+        "is_set": false
+      },
+      {
         "name": "vncviewer",
         "display_name": "RealVNC Viewer",
         "protocol": ["vnc"],

--- a/go-client/pkg/awaken/awaken_windows.go
+++ b/go-client/pkg/awaken/awaken_windows.go
@@ -61,8 +61,46 @@ func getCommandFromArgs(connectInfo map[string]string, argFormat string) string 
 }
 
 func handleRDP(r *Rouse, filePath string, cfg *config.AppConfig) *exec.Cmd {
-	cmd := exec.Command("C:\\WINDOWS\\system32\\mstsc.exe", filePath)
-	return cmd
+    if cfg != nil {
+        appLst := cfg.Windows.RemoteDesktop
+        for _, app := range appLst {
+            if !app.IsSet || !app.IsMatchProtocol("rdp") {
+                continue
+            }
+            appPath := app.Path
+            if app.IsInternal {
+                currentPath := filepath.Dir(os.Args[0])
+                candidate := filepath.Join(currentPath, app.Path)
+                if _, err := os.Stat(candidate); err == nil {
+                    appPath = candidate
+                }
+            }
+            if appPath == "" {
+                break
+            }
+            connectMap := map[string]string{
+                "file":     filePath,
+                "name":     r.getName(),
+                "protocol": r.Protocol,
+                "username": r.getUserName(),
+                "value":    r.Value,
+                "host":     r.Host,
+                "port":     strconv.Itoa(r.Port),
+            }
+            commands := strings.TrimSpace(getCommandFromArgs(connectMap, app.ArgFormat))
+            if commands == "" {
+                return exec.Command(appPath)
+            }
+            if strings.Contains(commands, "*") {
+                parts := strings.Split(commands, "*")
+                return exec.Command(appPath, parts...)
+            }
+            args := strings.Split(commands, " ")
+            return exec.Command(appPath, args...)
+        }
+    }
+    cmd := exec.Command("C:\\WINDOWS\\system32\\mstsc.exe", filePath)
+    return cmd
 }
 
 func handleVNC(r *Rouse, cfg *config.AppConfig) *exec.Cmd {


### PR DESCRIPTION
Summary
RDP is no longer hardcoded to mstsc.exe. The app now uses the first enabled client in windows.remotedesktop with match_first containing "rdp", falling back to mstsc if none.
Added Windows RDP presets (disabled by default): Royal TS, Remote Desktop Manager (Devolutions), MobaXterm.
Changes
go-client/pkg/awaken/awaken_windows.go: handleRDP now:
scans cfg.Windows.RemoteDesktop for enabled "rdp" match
expands arg_format placeholders ({file},{host},{port},{username},{value})
resolves internal paths relative to app dir
falls back to mstsc if no match
go-client/config.json:
Added three preset entries under windows.remotedesktop (royalts, windows_rdm, moba_rdp), empty path, is_set=false, arg_format: "{file}"
Why
Allow users to choose preferred RDP client (Royal TS, RDM, MobaXterm) without code changes.
Keeps backward compatibility via mstsc fallback.
How to use
1) Edit user config: C:\Users\<user>\AppData\Roaming\jumpserver-client\config.json
2) Under windows.remotedesktop:
Enable a preset (is_set: true)
Set path, e.g. "C:\\Program Files\\Royal TS V7\\RoyalTS.exe"
Ensure "protocol": ["rdp"], "match_first": ["rdp"]
Keep arg_format as "{file}" unless client needs a different format
3) Restart app; RDP connections launch the selected client.
Testing
Enabled Royal TS preset, set path, launched RDP asset → Royal TS opens with .rdp file.
Disabled preset; mstsc fallback verified.
Verified arg_format substitution and internal path resolution.
Compatibility
No breaking changes; default behavior remains mstsc when no client is enabled.
Notes
Presets ship disabled to avoid surprises.
If a client doesn’t accept .rdp, change arg_format accordingly (e.g., "/v:{host}:{port}") and remove {file}.