### PR TITLE
Avoid Windows tar drive-letter paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,9 +216,13 @@ jobs:
             exit 1
           fi
 
-          assets_dir="$RUNNER_TEMP/client-brand-assets"
-          archive_path="$RUNNER_TEMP/client-brand-assets.tgz"
+          # Keep these paths relative so Git Bash on Windows does not pass a
+          # drive-letter path like "D:\..." to tar, which tar treats as remote.
+          assets_root=".brand-assets-tmp"
+          assets_dir="$assets_root/client-brand-assets"
+          archive_path="$assets_root/client-brand-assets.tgz"
 
+          rm -rf "$assets_root"
           rm -rf "$assets_dir"
           mkdir -p "$assets_dir"
           openssl enc -d -aes-256-cbc -pbkdf2 -iter 200000 \


### PR DESCRIPTION
Git Bash on windows-latest expands RUNNER_TEMP to a drive-letter path. GNU tar treats paths containing a colon as remote archive syntax, so extracting the encrypted brand archive failed before the assets could be applied.

Constraint: The brand asset step runs with shell bash across macOS, Linux, and Windows runners
Constraint: Windows Git Bash paths such as D:\... are unsafe for tar -xzf
Rejected: Keep using RUNNER_TEMP | tar misinterprets the drive letter as a remote host separator on Windows
Confidence: high
Scope-risk: narrow
Directive: Keep brand asset temporary archive paths relative unless the extraction command is made Windows-path aware
Tested: Local openssl decrypt plus tar extract plus apply-brand-assets smoke copied 10 assets using relative .brand-assets-tmp paths
Not-tested: Full GitHub Actions windows-latest build