### PR TITLE
fix_client_connect_acl_branch_v1.0

### DIFF
--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -173,6 +173,7 @@
   "ConnectError": {
     "ConnectFailed": "Connection failed",
     "AclFailed": "The current asset is restricted by ACL policies and cannot be accessed via the client. Please use the Web console to connect.",
+    "ConnectMethodNotAllowed": "This connect method is prohibited by access control policy.",
     "ClientNotFound": "Desktop client not found. Please install or configure the client path.",
     "ClientLaunchFailed": "Failed to launch desktop client. Please check installation or permissions.",
     "ClientExited": "Desktop client exited unexpectedly.",

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -176,6 +176,7 @@
   "ConnectError": {
     "ConnectFailed": "连接失败",
     "AclFailed": "当前资产受到 ACL 访问限制，无法通过客户端连接，请前往 Web 端进行访问",
+    "ConnectMethodNotAllowed": "当前连接方式被访问控制策略禁止，无法连接",
     "ClientNotFound": "未找到桌面客户端，请安装或在设置中配置路径",
     "ClientLaunchFailed": "启动桌面客户端失败，请检查安装或权限",
     "ClientExited": "桌面客户端异常退出",

--- a/ui/components/EditForm/editForm.vue
+++ b/ui/components/EditForm/editForm.vue
@@ -27,7 +27,7 @@ const emits = defineEmits<{
 }>();
 
 const { t } = useI18n();
-const { getMethodsForProtocol, getDefaultMethodForProtocol } = useConnectMethods();
+const { getMethodsForProtocol, getDefaultMethodForProtocol, fetchConnectMethods } = useConnectMethods();
 // prettier-ignore
 const trailingIcon = "group-data-[state=open]:rotate-180 transition-transform duration-200";
 
@@ -79,14 +79,16 @@ watch(
   async (newProtocol) => {
     if (!newProtocol) return;
 
+    await fetchConnectMethods({ force: true });
     const methods = await getMethodsForProtocol(newProtocol);
     availableConnectMethods.value = methods;
 
-    if (!props.connectMethod || !methods.some((m) => m.value === props.connectMethod)) {
+    const currentValid = props.connectMethod
+      && methods.some((m) => m.value === props.connectMethod);
+    if (!currentValid) {
+      // 无可用方式时须清空，避免残留上一协议的 connectMethod（如 ssh_client）
       const defaultMethod = await getDefaultMethodForProtocol(newProtocol);
-      if (defaultMethod) {
-        emits("update:connectMethod", defaultMethod);
-      }
+      emits("update:connectMethod", defaultMethod);
     }
   },
   { immediate: true }

--- a/ui/composables/useAssetAction.ts
+++ b/ui/composables/useAssetAction.ts
@@ -2,6 +2,7 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
 import type { ConnectionBody, PermedAccount, PermedProtocol, TokenResponse } from "~/types";
 
 import { useSettingManager } from "~/composables/useSettingManager";
+import { useConnectMethods } from "~/composables/useConnectMethods";
 import { useUserInfoStore } from "~/store/modules/userInfo";
 
 let tauriListenersInitialized = false;
@@ -56,6 +57,7 @@ export const useAssetAction = () => {
   const toast = useToast();
   const userInfoStore = useUserInfoStore();
   const settingManager = useSettingManager();
+  const { getMethodsForProtocol, fetchConnectMethods } = useConnectMethods();
   // prettier-ignore
   const { currentSite, currentConnectionInfoMap, currentRdpClientOption } = storeToRefs(userInfoStore);
   const { charset, rdpResolution, backspaceAsCtrlH, keyboardLayout, rdpClientOption, rdpColorQuality, rdpSmartSize }
@@ -193,34 +195,15 @@ export const useAssetAction = () => {
   };
 
   /**
-   * @description 根据协议分发连接方法
-   * @param protocol
+   * @description 从服务端 ACL 过滤后的连接方式中解析可用方法
    */
-  const dispatchConnectMethod = (protocol: string) => {
-    let method = "";
-
-    switch (protocol) {
-      case "ssh":
-      case "telnet":
-        method = "ssh_client";
-        break;
-      case "rdp":
-        method = "mstsc";
-        break;
-      case "sftp":
-        method = "sftp_client";
-        break;
-      case "vnc":
-        method = "vnc_client";
-        break;
-      case "http":
-        method = "chrome";
-        break;
-      default:
-        method = "db_client";
+  const resolveConnectMethod = async (protocol: string, preferred?: string): Promise<string> => {
+    const methods = await getMethodsForProtocol(protocol);
+    const normalized = preferred?.trim();
+    if (normalized && methods.some((m) => m.value === normalized)) {
+      return normalized;
     }
-
-    return method;
+    return methods[0]?.value || "";
   };
 
   const generateConnectOptions = (protocol: string) => {
@@ -258,7 +241,7 @@ export const useAssetAction = () => {
    * @param accounts
    * @param protocolOverride
    */
-  const handleAssetConnection = (
+  const handleAssetConnection = async (
     user: string,
     assetId: string,
     displayProtocol: string,
@@ -320,10 +303,24 @@ export const useAssetAction = () => {
       return getUserId(accounts!, assetId, user);
     })();
 
+    await fetchConnectMethods({ force: true });
+
     // 当前连接显式选择优先；仅在协议一致时复用已保存连接方法，避免跨协议复用错误的客户端
-    const connectMethod = ephemeral?.connectMethod?.trim()
-      || (saved?.protocol === protocol ? saved?.connectMethod?.trim() : "")
-      || dispatchConnectMethod(protocol);
+    const preferredMethod = ephemeral?.connectMethod?.trim()
+      || (saved?.protocol === protocol ? saved?.connectMethod?.trim() : "");
+    const connectMethod = await resolveConnectMethod(protocol, preferredMethod);
+
+    if (!connectMethod) {
+      toast.add({
+        title: t("ConnectError.ConnectFailed"),
+        description: t("ConnectError.ConnectMethodNotAllowed"),
+        color: "error",
+        icon: "line-md:close-circle",
+        progress: true,
+        duration: 4000
+      });
+      return;
+    }
 
     userInfoStore.setConnectionInfoForAsset(assetId, {
       protocol,

--- a/ui/composables/useConnectMethods.ts
+++ b/ui/composables/useConnectMethods.ts
@@ -21,8 +21,16 @@ const fetchPromise = new Map<string, Promise<ConnectMethodsResponse>>();
 export const useConnectMethods = () => {
   const { currentSite, orgId } = storeToRefs(useUserInfoStore());
 
-  const fetchConnectMethods = async (): Promise<ConnectMethodsResponse> => {
-    const key = `${currentSite.value || ""}:${orgId.value || ""}`;
+  const getCacheKey = () => `${currentSite.value || ""}:${orgId.value || ""}`;
+
+  const fetchConnectMethods = async (options?: { force?: boolean }): Promise<ConnectMethodsResponse> => {
+    const key = getCacheKey();
+
+    if (options?.force) {
+      connectMethodsCache.delete(key);
+      fetchPromise.delete(key);
+    }
+
     const cached = connectMethodsCache.get(key);
 
     if (cached) {
@@ -117,6 +125,7 @@ export const useConnectMethods = () => {
 
   const clearCache = () => {
     connectMethodsCache.clear();
+    fetchPromise.clear();
   };
 
   return {


### PR DESCRIPTION
客户希望对某些用户限制VNC客户端的使用，实际上添加该限制规则时，仅对通过浏览器打开想调用客户端的方式生效。如果用户本身通过JS Client方式登录，依旧可以通过在客户端上连接来实现客户端的连接方式。相当于绕过了该规则限制。
<img width="1400" height="665" alt="image" src="https://github.com/user-attachments/assets/42b89a6e-95b7-4583-8156-526e51a4567c" />
目前代码的逻辑是：本地客户端创建Connection Token时，只校验了登录资产acl，没有校验连接方式acl。Core需要新增校验客户端连接方式的方法，主要是client端的逻辑需要加一层服务端连接当时acl校验。
实现的效果如下：
<img width="700" height="453" alt="image" src="https://github.com/user-attachments/assets/661c9a88-e573-4842-81fe-0ae0dc939355" />

代码改动 MarkDown：
