### PR TITLE
perf: update download URLs for TigerVNC plugins

### DIFF
--- a/plugins/linux/linux.tigervnc/manifest.json
+++ b/plugins/linux/linux.tigervnc/manifest.json
@@ -6,7 +6,7 @@
   "min_client_version": "4.0.0",
   "author": "JumpServer",
   "homepage": "https://github.com/jumpserver/clients",
-  "download_url": "https://sourceforge.net/projects/tigervnc/files/stable/1.15.0/tigervnc-1.15.0.x86_64.tar.gz",
+  "download_url": "https://sourceforge.net/projects/tigervnc/files/stable/1.16.2/tigervnc-1.16.2.x86_64.tar.gz",
   "category": "remotedesktop",
   "protocols": [
     "vnc"

--- a/plugins/macos/macos.tigervnc/connect.json
+++ b/plugins/macos/macos.tigervnc/connect.json
@@ -6,7 +6,7 @@
   "is_internal": false,
   "executable": {
     "type": "user_path",
-    "default": "/Applications/TigerVNC viewer 1.15.0.app/Contents/MacOS/TigerVNC viewer",
+    "default": "/Applications/TigerVNC.app/Contents/MacOS/vncviewer",
     "required": false
   },
   "launch": {

--- a/plugins/macos/macos.tigervnc/manifest.json
+++ b/plugins/macos/macos.tigervnc/manifest.json
@@ -6,7 +6,7 @@
   "min_client_version": "4.0.0",
   "author": "JumpServer",
   "homepage": "https://github.com/jumpserver/clients",
-  "download_url": "https://sourceforge.net/projects/tigervnc/files/stable/1.15.0/tigervnc-1.15.0.x86_64.tar.gz",
+  "download_url": "https://sourceforge.net/projects/tigervnc/files/stable/1.16.2/tigervnc-1.16.2.x86_64.tar.gz",
   "category": "remotedesktop",
   "protocols": [
     "vnc"

--- a/plugins/windows/windows.tigervnc/manifest.json
+++ b/plugins/windows/windows.tigervnc/manifest.json
@@ -6,7 +6,7 @@
   "min_client_version": "4.0.0",
   "author": "JumpServer",
   "homepage": "https://github.com/jumpserver/clients",
-  "download_url": "https://sourceforge.net/projects/tigervnc/files/stable/1.15.0/tigervnc-1.15.0.x86_64.tar.gz",
+  "download_url": "https://sourceforge.net/projects/tigervnc/files/stable/1.16.2/tigervnc-1.16.2.x86_64.tar.gz",
   "category": "remotedesktop",
   "protocols": [
     "vnc"


### PR DESCRIPTION
## Summary

- update TigerVNC download URLs from 1.15.0 to 1.16.2
- update the default macOS executable path for the current app bundle

## Verification

- validated all changed JSON files with jq
- confirmed the TigerVNC 1.16.2 download URL resolves successfully